### PR TITLE
Fix error checking in food controllers.

### DIFF
--- a/controllers/foodController.go
+++ b/controllers/foodController.go
@@ -59,7 +59,7 @@ func CreateFood(w http.ResponseWriter, r *http.Request) {
 	if file != nil {
 		avatarUrl, err := helper.SingleImageUpload(w, r, "food_image", config.EnvCloudFoodFolder())
 		if err != nil {
-			food_image = ""
+			avatarUrl = ""
 		}
 		food_image = avatarUrl
 	}
@@ -148,7 +148,7 @@ func UpdateFood(w http.ResponseWriter, r *http.Request) {
 	if file != nil {
 		avatarUrl, err := helper.SingleImageUpload(w, r, "food_image", config.EnvCloudFoodFolder())
 		if err != nil {
-			food_image = dbFood.Food_image
+			avatarUrl = dbFood.Food_image
 		}
 		food_image = avatarUrl
 	}


### PR DESCRIPTION
When an error occurs, it sets the `food_image` variable. However, it is immediately overridden after the error check block. Therefore, set `avatarUrl` instead so that value is used as `food_image`.